### PR TITLE
fix: 🐛 Added salt support for permit signature utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ export const createPermitSignature = async (
   owner: string,
   spender: string,
   value: BigNumber,
-  deadline: number
+  deadline: number,
+  salt?: string
 ): Promise<Signature> => {
   const nonce = await contract.nonces(owner);
   const name = await contract.name();
@@ -19,7 +20,8 @@ export const createPermitSignature = async (
         name,
         version,
         chainId,
-        verifyingContract: contract.address
+        verifyingContract: contract.address,
+        ...salt ? { salt } : {}
       },
       {
         Permit: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,12 @@ export const createPermitSignature = async (
   spender: string,
   value: BigNumber,
   deadline: number,
-  salt?: string
+  salt?: string,
+  versionOverride?: string
 ): Promise<Signature> => {
   const nonce = await contract.nonces(owner);
   const name = await contract.name();
-  const version = '1';
+  const version = versionOverride || '1';
   const chainId = await signer.getChainId();
 
   return ethers.utils.splitSignature(


### PR DESCRIPTION
Added support for `salt` in the `createPermitSignature` utility function.
This `salt` is an optional parameter which should be used for tokens (like USDC) which require it in the `permit` signature.
Also, in the `createPermitSignature` function has been added optional parameter for signature version override.